### PR TITLE
7tobias patch 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,16 +21,13 @@ Docker containers for Magento 2.4.x development including :
 3. `docker-compose build`
 4. `docker-compose up -d`   
 5. Install sample data
-
-docker-compose exec -u magento php-apache install-sampledata  
+`docker-compose exec -u magento php-apache install-sampledata`
 
 6. Install Magento
-
-docker-compose exec -u magento php-apache install-magento
+`docker-compose exec -u magento php-apache install-magento`
 
 7. Disable 2FA for testing
-
-docker-compose exec -u magento php-apache bin/magento module:disable Magento_TwoFactorAuth
+`docker-compose exec -u magento php-apache bin/magento module:disable Magento_TwoFactorAuth`
 
 ## Test
 
@@ -41,9 +38,9 @@ http://magento2.dev.com
  - CLI
 
 
-    docker-compose exec -u magento php-apache bash
+    `docker-compose exec -u magento php-apache bash`
 
-to fix layout issues with demo data : docker exec -i -t --user magento magento2_php-apache_1  cp /var/www/dev/magento2/vendor/magento/module-cms-sample-data/fixtures/styles.css /var/www/dev/magento2/pub/media/
+to fix layout issues with demo data : `docker-compose exec -u magento php-apache cp /var/www/dev/magento2/vendor/magento/module-cms-sample-data/fixtures/styles.css /var/www/dev/magento2/pub/media/`
 ### More
 
 https://blog.gaiterjones.com/docker-magento-2-development-deployment-php7-apache2-4-redis-varnish-scaleable/ for further deployment instructions.

--- a/README.md
+++ b/README.md
@@ -22,15 +22,15 @@ Docker containers for Magento 2.4.x development including :
 4. `docker-compose up -d`   
 5. Install sample data
 
-docker exec -i -t --user magento magento2_php-apache_1 install-sampledata  
+docker-compose exec -u magento php-apache install-sampledata  
 
 6. Install Magento
 
-docker exec -i -t --user magento magento2_php-apache_1 install-magento
+docker-compose exec -u magento php-apache install-magento
 
 7. Disable 2FA for testing
 
-docker exec -i -t --user magento magento2_php-apache_1 bin/magento module:disable Magento_TwoFactorAuth
+docker-compose exec -u magento php-apache bin/magento module:disable Magento_TwoFactorAuth
 
 ## Test
 
@@ -41,7 +41,7 @@ http://magento2.dev.com
  - CLI
 
 
-    docker exec -i -t --user magento magento2_php-apache_1 /bin/bash
+    docker-compose exec -u magento php-apache bash
 
 to fix layout issues with demo data : docker exec -i -t --user magento magento2_php-apache_1  cp /var/www/dev/magento2/vendor/magento/module-cms-sample-data/fixtures/styles.css /var/www/dev/magento2/pub/media/
 ### More


### PR DESCRIPTION
This is just a suggestion to exchange the docker by docker-compose commands. When a beginner starts with docker-compose it is confusing when half of the howto is switching from docker-compose to docker commands with a different syntax without a good reason.  
For the experienced user it might not be a big issue also when only having one instance on the host. But overall I think staying within one command environment it is more straigt forward.

I also harmonized the formatting in the readme by copying backticks to the other commands.